### PR TITLE
Reduce AI review frequency: once per PR open + manual dispatch, with merge gate

### DIFF
--- a/.github/workflows/pr-review-gate.yaml
+++ b/.github/workflows/pr-review-gate.yaml
@@ -2,18 +2,53 @@ name: AI Review Gate
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened, ready_for_review]
+    types: [synchronize, reopened, ready_for_review]
+  workflow_run:
+    workflows: ["AI Infrastructure Review"]
+    types: [completed]
 
 permissions:
   pull-requests: read
   actions: read
+  checks: write
 
 jobs:
   gate:
     name: AI review required
     runs-on: ubuntu-latest
     steps:
-      - name: Check if AI review has run
+      # When the review workflow just finished, mirror its result onto the PR head SHA.
+      # This path runs on the default branch so we must create the check explicitly.
+      - name: Mirror review result to PR head
+        if: github.event_name == 'workflow_run'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const wf = context.payload.workflow_run;
+            const pr = wf.pull_requests[0];
+            if (!pr) {
+              core.info('No PR associated with this workflow run (likely workflow_dispatch), skipping.');
+              return;
+            }
+            const passed = wf.conclusion === 'success';
+            await github.rest.checks.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              name: 'AI review required',
+              head_sha: pr.head.sha,
+              status: 'completed',
+              conclusion: passed ? 'success' : 'failure',
+              output: {
+                title: passed ? 'AI review passed' : 'AI review required',
+                summary: passed
+                  ? 'The AI Infrastructure Review completed successfully.'
+                  : `AI Infrastructure Review ended with conclusion: ${wf.conclusion}. Check the review workflow for details.`
+              }
+            });
+
+      # On subsequent pushes, verify at least one passing review exists for this PR.
+      - name: Check if AI review has passed
+        if: github.event_name == 'pull_request'
         env:
           GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ github.event.pull_request.number }}

--- a/.github/workflows/pr-review-gate.yaml
+++ b/.github/workflows/pr-review-gate.yaml
@@ -1,0 +1,35 @@
+name: AI Review Gate
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+permissions:
+  pull-requests: read
+  actions: read
+
+jobs:
+  gate:
+    name: AI review required
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check if AI review has run
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          RESULT=$(gh api "/repos/$REPO/actions/workflows/pr-review.yaml/runs" \
+            --jq "[.workflow_runs[] | select(
+              (.pull_requests | length > 0) and
+              (.pull_requests[].number == ($PR_NUMBER | tonumber)) and
+              .conclusion == \"success\"
+            )] | length")
+
+          if [ "${RESULT:-0}" -gt 0 ]; then
+            echo "AI Infrastructure Review has passed for PR #$PR_NUMBER."
+          else
+            echo "No passing AI Infrastructure Review found for PR #$PR_NUMBER."
+            echo "Trigger it via: Actions → AI Infrastructure Review → Run workflow (pr_number: $PR_NUMBER)"
+            exit 1
+          fi

--- a/.github/workflows/pr-review.yaml
+++ b/.github/workflows/pr-review.yaml
@@ -2,10 +2,16 @@ name: AI Infrastructure Review
 
 on:
   pull_request:
-    types: [opened, synchronize]
+    types: [opened]
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: 'PR number to review'
+        required: true
+        type: string
 
 concurrency:
-  group: pr-review-${{ github.event.pull_request.number }}
+  group: pr-review-${{ inputs.pr_number || github.event.pull_request.number }}
   cancel-in-progress: true
 
 permissions:
@@ -22,6 +28,7 @@ jobs:
         id: skip-check
         env:
           GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ inputs.pr_number || github.event.pull_request.number }}
         run: |
           # Skip if commit message contains [skip-review] or [no-review]
           COMMIT_MSG=$(git log -1 --pretty=%B)
@@ -32,7 +39,7 @@ jobs:
           fi
 
           # Skip if all changed files are documentation
-          CHANGED=$(gh pr view ${{ github.event.pull_request.number }} \
+          CHANGED=$(gh pr view "$PR_NUMBER" \
             --json files --jq '[.files[].path]')
           TOTAL=$(echo "$CHANGED" | jq 'length')
           DOCS=$(echo "$CHANGED" | \
@@ -44,7 +51,7 @@ jobs:
           fi
 
           # Skip if the diff is too small (<20 changed lines)
-          DIFF_LINES=$(gh pr diff ${{ github.event.pull_request.number }} | \
+          DIFF_LINES=$(gh pr diff "$PR_NUMBER" | \
             grep -cE '^[+-][^+-]' || true)
           if [ "$DIFF_LINES" -lt 20 ]; then
             echo "skip=true" >> "$GITHUB_OUTPUT"
@@ -58,14 +65,15 @@ jobs:
         if: steps.skip-check.outputs.skip != 'true'
         env:
           GH_TOKEN: ${{ github.token }}
-        run: gh pr diff ${{ github.event.pull_request.number }} > /tmp/pr.diff
+          PR_NUMBER: ${{ inputs.pr_number || github.event.pull_request.number }}
+        run: gh pr diff "$PR_NUMBER" > /tmp/pr.diff
 
       - name: Review with Claude
         if: steps.skip-check.outputs.skip != 'true'
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           GH_TOKEN: ${{ github.token }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_NUMBER: ${{ inputs.pr_number || github.event.pull_request.number }}
           REPO: ${{ github.repository }}
         run: |
           python3 << 'PYEOF'

--- a/cluster/ansible/node-state.yaml
+++ b/cluster/ansible/node-state.yaml
@@ -145,7 +145,7 @@
         line: '\1 systemd.unified_cgroup_hierarchy=1'
       register: arm_cgroup_v2
 
-    - name: x86 — ensure cgroup v2 unified hierarchy in GRUB
+    - name: X86 — ensure cgroup v2 unified hierarchy in GRUB
       when: ansible_architecture == "x86_64"
       ansible.builtin.lineinfile:
         path: /etc/default/grub
@@ -154,7 +154,7 @@
         line: '\1 systemd.unified_cgroup_hierarchy=1"'
       register: x86_cgroup_v2
 
-    - name: x86 — ensure cgroup memory/cpuset flags in GRUB
+    - name: X86 — ensure cgroup memory/cpuset flags in GRUB
       when: ansible_architecture == "x86_64"
       ansible.builtin.lineinfile:
         path: /etc/default/grub
@@ -163,7 +163,7 @@
         line: '\1 cgroup_enable=cpuset cgroup_memory=1 cgroup_enable=memory"'
       register: x86_cgroup_memory
 
-    - name: x86 — update GRUB config
+    - name: X86 — update GRUB config
       when: ansible_architecture == "x86_64" and (x86_cgroup_v2.changed or x86_cgroup_memory.changed)
       ansible.builtin.command: update-grub
 


### PR DESCRIPTION
## Summary

- Remove `synchronize` trigger from `pr-review.yaml` so the expensive Claude Opus review no longer fires on every push — only on PR open
- Add `workflow_dispatch` with a `pr_number` input so reviewers can manually re-trigger from the Actions UI
- Add new `pr-review-gate.yaml`: a lightweight check that runs on every push and verifies the review has completed at least once for the PR

## How it works

**Review workflow** (`AI Infrastructure Review`): slow, expensive — runs on `opened` and `workflow_dispatch` only.

**Gate workflow** (`AI review required`): fast, free — runs on every push. Checks the GitHub API for any successful `pr-review.yaml` run associated with this PR. Passes if one exists; fails with instructions otherwise.

## Manual trigger

Go to **Actions → AI Infrastructure Review → Run workflow**, enter the PR number. Useful after significant changes to a PR that was already reviewed.

## Required follow-up (manual)

Add **`AI review required`** as a required status check in **Settings → Branches → Branch protection rules** for `master`. This gates merges on the lightweight check, not the expensive review.

## Behaviour by scenario

| Event | pr-review runs? | gate runs? |
|---|---|---|
| PR opened (substantive) | Yes | Yes (waits for review) |
| PR opened (docs-only/tiny) | Yes (skips, exits success) | Yes (passes immediately) |
| Push to existing PR | No | Yes (passes if review already ran) |
| `workflow_dispatch` | Yes | No (gate picks it up on next push) |

https://claude.ai/code/session_01AqUJR2jJc3PrqLZeL6Rsmz

---
_Generated by [Claude Code](https://claude.ai/code/session_01AqUJR2jJc3PrqLZeL6Rsmz)_