### PR TITLE
docs: add directory-scoped CLAUDE.md files with agent guardrails

### DIFF
--- a/.github/AGENTS.md
+++ b/.github/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/.github/CLAUDE.md
+++ b/.github/CLAUDE.md
@@ -1,0 +1,28 @@
+# .github/CLAUDE.md — CI workflows and the autofix loop
+
+## Workflow inventory
+
+- `workflows/lint.yaml` — `yamllint` + `kubeconform` + `ansible-lint`.
+- `workflows/test-ansible.yaml` — three jobs: shoebox validators (`shoebox/tests/*.sh`), monkeyble (`cluster/ansible/tests/monkeyble/run-tests.sh`), molecule (`cluster/ansible/molecule/`).
+- `workflows/test-cluster.yaml` — k3d smoke test: spins up a local cluster and applies manifests.
+- `workflows/pr-review.yaml` + `workflows/pr-review-gate.yaml` — Claude AI review + status-check gate.
+- `workflows/autofix.yaml` — fires on `lint.yaml` / `test-cluster.yaml` failure; runs `scripts/autofix.py` (Claude agentic loop: read_file / write_file / run_bash; commits + comments).
+
+## `autofix.py` invariants — DO NOT BREAK
+
+**IMPORTANT.** The autofix loop is the only thing keeping CI green without manual intervention. When editing `scripts/autofix.py`:
+
+- **Read-only bash allowlist stays in place.** No `curl`, no commands that can exfiltrate secrets.
+- **Same-repo PRs only.** No forks — write permission would leak.
+- **Autofix commits MUST carry `[autofix]` in the subject** so this workflow does not re-loop on its own pushes. The marker check happens early; removing it deadlocks CI.
+- Any change to `autofix.py` needs a spec + a dry-run before merge.
+
+## Commit subject markers
+
+- `[autofix]` — autofix workflow ignores (anti-loop).
+- `[skip-review]` or `[no-review]` — AI review skipped.
+- `[Claude]` — bot-authored attribution.
+
+## Exception files
+
+- `agentic-review-exceptions.yaml` documents dismissed AI-review findings. Update intentionally when adding/removing a known finding; **never** as a way to silence a real failure.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,72 @@
+# CLAUDE.md — repo-wide rules for agents
+
+This is a homelab k3s cluster's docs + IaC: K8s manifests + Helm overrides in `cluster/`, Ansible (playbooks + roles + tests) in `cluster/ansible/`, an external Ansible runner in `shoebox/`, CI in `.github/`. For project context read `@README.md`, `@dns.md`, `@nextcloud.md`, `@warehouse.md`, `@ansible-scheduler.md`.
+
+Every directory has its own `CLAUDE.md` (with `AGENTS.md` symlink); Claude Code loads each from cwd up to repo root, so this file holds only the cross-cutting rules.
+
+## Workflow — NON-NEGOTIABLE
+
+**IMPORTANT.** Every change follows this workflow. YOU MUST NOT skip steps.
+
+- **Decompose first.** Large feature requests get broken into the smallest set of atomic GitHub Issues, presented as a numbered list with an explicit **sequencing graph** (`#3 blocks #4,#5`; `#6,#7 parallel after #4`). An Issue is "atomic" if it has a single testable acceptance criterion AND its PR(s) can merge without simultaneously requiring another Issue's PR — *not* "doesn't change the cluster".
+- **Spec-first (per Issue).** Before any diff: intent, target namespace/host/inventory group, resources touched, expected end-state, rollback path, out-of-scope items. Non-trivial → PR description or `wip/SPEC.md`; trivial → first sentences of the commit body. **No diff without a spec.**
+- **Test-first AND review tests vs spec.** Add the failing check before the implementation; review tests against the spec for *coverage* and *effectiveness* (would they catch a regression?) **before** writing code, **before** commit, and again at PR review.
+- **CI/test coverage may need expansion.** If existing frameworks don't adequately cover the change, the spec MUST include extending them — new `monkeyble` scenario, new `molecule` verify, new `test-cluster.yaml` step, new `shoebox/tests/` case. "We don't have a test for this kind of thing" is not an excuse to skip test-first.
+- **PR size limits (hard).** Warn at **≥200 LOC** changed (added + removed, non-generated). At **≥400 LOC the PR MUST be split** before merge. When the warning hits, propose the split with the same sequencing-graph format.
+- **Issue ↔ PR is 1:N, never N:1.** Each PR addresses exactly one Issue. One Issue MAY span multiple PRs if it doesn't fit; decompose its acceptance criteria inside the Issue, each PR satisfies a labelled subset.
+- **Constrain scope; minimal changes; ask before straying.** Smallest diff that satisfies the spec. No adjacent refactors. **Do not modify files outside the Issue's declared scope without asking** — a typo fix in an unrelated file is its own Issue. If the operator expands scope mid-flight, push back: name the expansion, propose it as a new Issue with its place in the graph, finish the original.
+- **Prefer established upstream/community components over scripted glue.** Order: (1) upstream Helm chart + our values, (2) community operator/controller, (3) vendored upstream manifest, (4) raw manifest we author. Bash scripts, `curl | sh` init containers, one-off `kubectl` in CI are the **last** resort and require justification in the spec. Ansible: Galaxy roles/collections in `requirements.yaml` over hand-rolled `command:` / `shell:`.
+- **Run tests before commit; fix failures, don't commit around them.** Never commit with known-failing tests, never silence a test or add to an exception file to make CI green, never `--no-verify`.
+
+## Repository map
+
+| Path | What lives here | Nearest leaf `CLAUDE.md` |
+|---|---|---|
+| `cluster/` | All Kubernetes resources + node Ansible | `cluster/CLAUDE.md` |
+| `cluster/services/` | Application workloads (raw YAML) | `cluster/services/CLAUDE.md` |
+| `cluster/ansible/` | Playbooks, roles, monkeyble + molecule tests | `cluster/ansible/CLAUDE.md` |
+| `cluster/helm/` | Values overrides for upstream charts | `cluster/helm/CLAUDE.md` |
+| `cluster/storage/` | PV/PVC for stateful services | `cluster/storage/CLAUDE.md` |
+| `shoebox/` | External Ansible runner (Semaphore in Docker) | `shoebox/CLAUDE.md` |
+| `.github/` | CI workflows + autofix script | `.github/CLAUDE.md` |
+| root `*.md` | Operator architecture docs (imported above) | — |
+
+## Secrets — never in repo
+
+**NEVER** commit plaintext secrets. No `*.key` (gitignored under `cluster/keys/`). **NEVER resolve `CHANGEME_*` placeholders** — leave them literal even if the operator pastes a real value in chat. Ansible secrets live in vault (`--ask-vault-pass`). Shoebox uses `SEMAPHORE_ACCESS_KEY_ENCRYPTION` as an env var on the host, validated by `shoebox/scripts/validate-semaphore-key.sh`. Obvious fake tokens like `ci-test-token` are intentional CI fixtures — do not "fix" them.
+
+## Universal linters and exceptions
+
+Repo-wide gating linters apply to every directory:
+
+- `yamllint` (config `.yamllint.yaml` — line length 160, lax booleans)
+- `ansible-lint` (config `.ansible-lint`) — runs on **any** Ansible file in the diff, whether in `cluster/ansible/` or `shoebox/`
+- `shellcheck` on every `*.sh`
+
+K8s-specific linters (`kubeconform`, `kube-score`, `polaris`, `hadolint`) live in `cluster/CLAUDE.md`.
+
+**Consult before "fixing" a finding:**
+- `.trivyignore` — documented homelab tradeoffs (linuxserver images, nodelocaldns privileged, cert-manager).
+- `.github/agentic-review-exceptions.yaml` — dismissed AI-review findings; do not re-raise.
+
+## Universal verification — before every commit
+
+```sh
+yamllint .
+shellcheck $(git ls-files '*.sh')
+ansible-lint <touched-ansible-paths>   # any Ansible file in the diff
+```
+
+**Then run the directory-specific verification listed in the nearest leaf `CLAUDE.md` for every directory your diff touches.** Each leaf owns checks relevant only to its subtree. Green before commit; never silence to commit.
+
+## Commit + PR etiquette
+
+- Imperative mood, lowercase start, short subject; `feat:` / `fix:` prefix optional.
+- Bot commits carry `[Claude]` attribution.
+- Autofix commits carry `[autofix]` so `autofix.yaml` doesn't re-loop.
+- `[skip-review]` or `[no-review]` skips AI review.
+- Open PRs as **draft** until self-review + local tests pass.
+
+## Documentation style
+
+Terse, operator-first; real names (`warehouse`, `shoebox`, `Pi-hole`, `k3s`, `Longhorn`, `MetalLB`, `traefik`, `cloudflared`, `Semaphore`). No marketing prose, no emojis, no "in conclusion" sections.

--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ k3s nodes:
 
 All services run on kubernetes, with the yaml files listed in the `cluster/` subdirectory.
 
+Per-directory `CLAUDE.md` (with `AGENTS.md` symlink) files document the conventions for agents working in each subtree.
+
 Nodes with a useful GPU - ie a recent enough generation for video transcoding - are labeled with transcodingGpu=1.
 
 Access to all the machines is keyed on my ssh keypair.

--- a/cluster/AGENTS.md
+++ b/cluster/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/cluster/CLAUDE.md
+++ b/cluster/CLAUDE.md
@@ -1,0 +1,35 @@
+# cluster/CLAUDE.md — shared Kubernetes foundation
+
+Loaded for every directory under `cluster/`. The root `CLAUDE.md` covers cross-cutting workflow + secrets + universal lint; this file adds Kubernetes-specific foundation that `services/`, `helm/`, `storage/`, and the thin K8s-resource dirs (`ConfigMaps/`, `jobs/`, `ingress-only/`, etc.) all rely on. `cluster/ansible/` inherits it as well; its content is largely K8s-irrelevant for OS-provisioning, which is the cost of not hoisting `cluster/ansible/` to root `/ansible/` in this PR.
+
+## Manifest foundation
+
+- **`metadata.namespace` is ALWAYS explicit** on every resource. Never rely on the default namespace.
+- **Default resource requests** inherit from `cluster/default-limits-requests.yaml`; never omit `resources.requests`.
+- **Priority classes** live in `cluster/priorityClasses/`.
+- **Storage references** use the `pv-<workload>` / `pvc-<workload>` names from `cluster/storage/`; no inline `hostPath` except in `cluster/debugging/` where the existing pattern already uses it.
+
+## K8s-specific linters
+
+- `kubeconform` — gating; schema validation.
+- `kube-score` — advisory; policy scoring. Read the output.
+- `polaris` — advisory; best-practices audit. Read the output.
+- `hadolint` (config `.hadolint.yaml`) — for any Dockerfile under `cluster/Dockerfiles/`.
+
+New advisory findings need either a justified entry in `.github/agentic-review-exceptions.yaml` or a fix — not silent acceptance.
+
+## K8s verification — run before commit when any manifest under `cluster/` changes
+
+```sh
+kubeconform -summary -strict -ignore-missing-schemas cluster/
+kube-score score cluster/**/*.yaml
+polaris audit --audit-path cluster/
+hadolint $(git ls-files 'cluster/Dockerfiles/**')   # if any Dockerfile changed
+```
+
+**For a new workload**, extend `.github/workflows/test-cluster.yaml` with an apply + `kubectl wait --for=condition=Ready` step (test-first), then reproduce locally:
+
+```sh
+k3d cluster create homenet-test --config .github/k3d-config.yaml
+# then re-run the workflow's apply/install steps; watch the wait pass
+```

--- a/cluster/ansible/AGENTS.md
+++ b/cluster/ansible/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/cluster/ansible/CLAUDE.md
+++ b/cluster/ansible/CLAUDE.md
@@ -1,0 +1,39 @@
+# cluster/ansible/CLAUDE.md — node provisioning + rolling upgrades
+
+Playbooks here provision the k3s nodes' OS (apt, sysctl, k3s service, NTP, iSCSI). They run from `shoebox/` via Semaphore — never in-cluster. See `@ansible-scheduler.md` for the runner architecture.
+
+## Playbook contracts
+
+- **`node-state.yaml`** — fully idempotent; converges packages, kernel modules, sysctl, NTP, iSCSI, swap, journald. Safe to re-run.
+- **`rolling-upgrade.yaml`** — `apt dist-upgrade` + reboot + health check + uncordon; `serial: 1`; agents → multimasters → masters (first-master last); rescue path on health failure.
+- **`rolling-release-upgrade.yaml`** — Ubuntu major-version `do-release-upgrade`; same serial/rescue pattern as `rolling-upgrade.yaml`.
+- **`k3s-agent.yaml`** — legacy one-time bootstrap for a fresh node; **NOT idempotent**. Requires `--ask-become-pass --ask-vault-pass` and `new_hostname` / `k3s_token` / `usb_disk` / `cluster_role` vars.
+- **`rename-node.yaml`**, **`showfacts.yaml`** — utility, obvious from name.
+
+## Roles (`roles/`)
+
+`apt_upgrade`, `cordon_drain`, `k3s_health`, `node_state`, `release_upgrade`, `upgrade_checks_cp`, `upgrade_pre_state`, `upgrade_rescue_agent`, `upgrade_rescue_cp`. Roles compose into the rolling playbooks — **do not duplicate role logic inline** in a playbook.
+
+## State, failure flag, alerts
+
+- All upgrade plays read/write state under `/var/lib/ansible-upgrade/` on the shoebox host (not in repo).
+- A persistent failure flag (`rolling-upgrade-failed`) **aborts subsequent plays** in the same run — agents-fail blocks multimasters-then-masters. Clearing the flag is the rescue path's job; never clear it silently.
+- **Pushover alerts:** `WARNING` when an auto-rebuild succeeded; `CRITICAL` for unrecovered failures (CP failure, agent rebuild failed). New rescue paths follow this severity contract.
+- **kubectl from playbooks:** `delegate_to: localhost` with `$KUBECONFIG` set to shoebox's kubeconfig. Never run kubectl on the target node.
+
+## Tests (`tests/` + `molecule/`)
+
+- `tests/monkeyble/` — `hpe.monkeyble` mocks of kubectl/apt/systemctl. Scenarios: `test_agent_rescue_success.yml`, `test_agent_rescue_failure.yml`, plus `cross_play_abort` orchestrated by `run-tests.sh` (which disables monkeyble for that scenario — tests Ansible flow, not assertions).
+- `molecule/default/` — Docker (`ubuntu2204-ansible`) converge + idempotence + verify of `node_state`. Uses `--skip-tags molecule-notest` to skip x86 media + multipath removal.
+
+**Test-first contract for Ansible changes:** any change touching a role MUST add or update either a monkeyble scenario (control flow / assertions) or a molecule verify step (converged state). Re-run both before commit.
+
+## Verification — run before commit
+
+```sh
+ansible-lint cluster/ansible
+bash cluster/ansible/tests/monkeyble/run-tests.sh
+cd cluster/ansible && molecule test
+```
+
+If existing scenarios don't cover your change, add one — per the root "CI/test coverage may need expansion" rule. Collections (`requirements.yaml`) currently include `ansible.posix` + `hpe.monkeyble`; prefer Galaxy collections over hand-rolled `command:` / `shell:`.

--- a/cluster/helm/AGENTS.md
+++ b/cluster/helm/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/cluster/helm/CLAUDE.md
+++ b/cluster/helm/CLAUDE.md
@@ -1,0 +1,17 @@
+# cluster/helm/CLAUDE.md — values overrides for upstream charts
+
+This directory holds **values overrides for upstream charts, NOT chart sources.** Two carve-outs:
+
+- `collabora/` — hand-built chart (Collabora Online).
+- `wip/` — experimental charts (`kube-plex`, `longhorn`, `mariadb-galera`, `percona-xtradb`). Incomplete by definition. Do **NOT** promote to root `helm/` without a spec + green smoke.
+
+CI installs the upstream chart and applies the local `values.yaml` / `override.yaml`.
+
+## Helm-specific verification — in addition to `cluster/CLAUDE.md` K8s checks
+
+```sh
+helm template <chart> cluster/helm/<chart> -f cluster/helm/<chart>/values.yaml \
+  | kubeconform -strict -ignore-missing-schemas -
+```
+
+Run this for every touched chart override. For a real upgrade path, extend `.github/workflows/test-cluster.yaml`'s `helm upgrade --install --dry-run` invocation to cover the override.

--- a/cluster/services/AGENTS.md
+++ b/cluster/services/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/cluster/services/CLAUDE.md
+++ b/cluster/services/CLAUDE.md
@@ -1,0 +1,25 @@
+# cluster/services/CLAUDE.md — application workloads
+
+Raw Kubernetes YAML (not Helm). Foundation (namespace, resource requests, storage refs, K8s linters + verification) lives in `cluster/CLAUDE.md` and is not restated here.
+
+## Conventions
+
+- Multi-resource files are normal.
+- Naming: lowercase kebab-case.
+- `Service.spec.selector` must match `Deployment.spec.template.metadata.labels`. Mismatches silently break routing.
+- Per-service subdirectory when a service has >2 resources (see `octoprint/`, `unifi/`); flat single file otherwise.
+
+## Health probes — REQUIRED on every container
+
+**YOU MUST** declare `readinessProbe` AND `livenessProbe` on every container of every `Deployment` / `StatefulSet` / `DaemonSet`. Add `startupProbe` when boot can exceed 10s.
+
+- HTTP services → `httpGet` against a **real** health endpoint, not `/`. Use `/healthz`, `/ready`, `/api/health`, or whatever the upstream image actually exposes.
+- TCP-only services → `tcpSocket` on the real listening port.
+- Non-network workloads → meaningful `exec` (e.g., `pgrep -f <daemon>`, `test -f /run/<lockfile>`).
+- **No-op probes are NOT acceptable**: never `exec: ["true"]`, never a script that always returns 0, never a probe that hits a static asset.
+
+Tune `initialDelaySeconds`, `periodSeconds`, `failureThreshold` to the actual workload — copy-pasted defaults are not tuning. Add a one-line comment explaining any non-obvious choice (e.g., `# slow JVM startup, 90s grace`).
+
+## When a probe genuinely can't be added
+
+Document why in the spec (e.g., closed-source binary with no health surface). Get explicit operator sign-off in the PR before merging. Do not work around it by adding a no-op probe — declare its absence explicitly with a comment in the manifest.

--- a/cluster/storage/AGENTS.md
+++ b/cluster/storage/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/cluster/storage/CLAUDE.md
+++ b/cluster/storage/CLAUDE.md
@@ -1,0 +1,12 @@
+# cluster/storage/CLAUDE.md — PV and PVC manifests
+
+K8s verification (kubeconform etc.) lives in `cluster/CLAUDE.md`.
+
+## Conventions
+
+- File names match resource names: `pv-<workload>.yaml`, `pvc-<workload>.yaml`. One workload per file.
+- `StorageClass` choice:
+  - **Longhorn** (variants in `cluster/StorageClass/`) for cluster-internal replicated storage.
+  - **`nfs-subdir-external-provisioner`** for shared host-mounted volumes (warehouse, shoebox).
+- `persistentVolumeReclaimPolicy: Retain` for data PVs by default. `Delete` only for ephemeral/throwaway.
+- PVCs reference their PV by name, not by selector, to keep binding deterministic.

--- a/shoebox/AGENTS.md
+++ b/shoebox/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/shoebox/CLAUDE.md
+++ b/shoebox/CLAUDE.md
@@ -1,0 +1,26 @@
+# shoebox/CLAUDE.md — external Ansible runner
+
+Shoebox is the always-on NFS host. It runs Semaphore UI in Docker to **schedule** the playbooks in `cluster/ansible/` against the k3s cluster. It cannot move into the cluster (observer paradox: the cluster dies during upgrades, so the scheduler can't drive uncordon). See `@ansible-scheduler.md` for the architecture; Ansible foundation (ansible-lint, vault, Galaxy preference) lives in the root `CLAUDE.md`.
+
+## Layout
+
+- `semaphore/docker-compose.yaml` — Semaphore v2.10.22 (port 3000) + Python deps from `requirements.txt`.
+- `scripts/validate-semaphore-key.sh` — validates `SEMAPHORE_ACCESS_KEY_ENCRYPTION` (URL-safe base64, exact length, no whitespace).
+- `tests/test-validate-semaphore-key.sh` — unit tests for the validator.
+- `shoebox-ansible-setup.yaml` — bootstrap playbook; runs from the operator's workstation against the shoebox host.
+
+## Conventions
+
+- **`SEMAPHORE_ACCESS_KEY_ENCRYPTION` is an env var on the shoebox host, never in repo.** Any change to its format MUST update both the validator and its tests (test-first).
+- **Bash scripts:** every script starts with `set -euo pipefail`; every script is `shellcheck`-clean; every script has a unit test under `shoebox/tests/`.
+- **No kubectl in shoebox scripts.** kubectl access from playbooks uses `delegate_to: localhost` with shoebox's kubeconfig (on the host, not in repo).
+- **State and log dirs on the shoebox host:** `/var/lib/ansible-upgrade/` (upgrade state, maintenance flags) and `/var/log/ansible/` (run history). Any script that writes here documents the path inline with a comment.
+
+## Verification — run before commit
+
+```sh
+bash shoebox/tests/test-validate-semaphore-key.sh
+shellcheck shoebox/scripts/*.sh shoebox/tests/*.sh
+```
+
+(Bootstrap playbook is covered by the root universal `ansible-lint` step.) For a new validator, follow test-first: add a failing case under `shoebox/tests/` before writing the script.


### PR DESCRIPTION
## Summary

Adds eight `CLAUDE.md` files (with sibling `AGENTS.md` symlinks for AGENTS.md-aware agent interop) to give agents and the operator persistent, scoped context per directory. Claude Code auto-loads each `CLAUDE.md` from the cwd up to the repo root; per-directory scoping keeps the aggregate at any leaf small.

| Path | Lines | Aggregate at this leaf |
|---|---|---|
| `CLAUDE.md` (root) | 72 | 72 |
| `cluster/CLAUDE.md` | 35 | 107 |
| `cluster/services/CLAUDE.md` | 25 | 132 |
| `cluster/ansible/CLAUDE.md` | 39 | 146 |
| `cluster/helm/CLAUDE.md` | 17 | 124 |
| `cluster/storage/CLAUDE.md` | 12 | 119 |
| `shoebox/CLAUDE.md` | 26 | 98 |
| `.github/CLAUDE.md` | 28 | 100 |

Every leaf aggregate is well under the 200-line cap.

### What's in each

- **Root** — workflow rules (decompose → spec → test → minimal → scope-bounded → run tests → PR-size limits), repo map, secrets, universal lint (yamllint, ansible-lint for any Ansible path, shellcheck), commit + PR etiquette.
- **`cluster/`** — shared K8s foundation (`metadata.namespace` always explicit, resource requests, priority classes, storage refs); K8s linters (kubeconform gating; kube-score + polaris advisory; hadolint); k3d smoke reproduction.
- **`cluster/services/`** — raw-YAML manifest conventions, required `readinessProbe`/`livenessProbe`/`startupProbe` (no-op probes prohibited), naming, per-service subdir pattern.
- **`cluster/ansible/`** — playbook contracts (3 rolling-upgrade variants + node-state + utility); role map; state-dir + persistent failure flag; Pushover WARNING vs CRITICAL severity contract; `delegate_to: localhost` + kubeconfig pattern; monkeyble + molecule test layout; Ansible test-first contract.
- **`cluster/helm/`** — overrides not chart sources; `wip/` carve-out; `helm template | kubeconform` verification.
- **`cluster/storage/`** — `pv-`/`pvc-` naming, Longhorn vs `nfs-subdir-external-provisioner` choice, `Retain` default reclaim.
- **`shoebox/`** — external-runner role (Semaphore in Docker); validator-script pattern with `set -euo pipefail` + unit test; `SEMAPHORE_ACCESS_KEY_ENCRYPTION` env-var rule; state/log dirs on host.
- **`.github/`** — workflow inventory; `autofix.py` invariants (read-only bash allowlist, same-repo PRs only, `[autofix]` anti-loop marker); commit subject markers; `agentic-review-exceptions.yaml` usage.

`README.md` gets a single line pointing humans at the per-directory files.

## PR-size warning (intentional, declared up front)

This PR is **264 LOC** — above the 200-LOC warning threshold defined in the new root `CLAUDE.md`, comfortably under the 400-LOC hard-split limit. Splitting introduces a broken intermediate state (root references leaves that wouldn't exist yet), so I'm proposing a single PR. If you'd prefer a split, the natural sequencing is:

1. **B.1 — Foundation (~150 LOC):** root `CLAUDE.md` + `AGENTS.md`, `cluster/CLAUDE.md` + symlink, README.md pointer. Establishes workflow + K8s foundation; lands first.
2. **B.2 — Leaves (~115 LOC, parallel after B.1):** the six per-directory leaf files + symlinks. Adds specifics.

Say the word and I'll re-split.

## Comprehensibility check (both audiences)

Read each new `CLAUDE.md` cold from an agent's POV and the operator's POV; cross-referenced against the corresponding existing README where one exists:

- `cluster/ansible/README.md` — no contradictions. README is operator-facing and goes deeper on vault mechanics (`-e vault_file=…`), command examples, and the variables table; CLAUDE.md adds the rolling-release-upgrade playbook, role map, state-dir + Pushover contract, and the test-first rule that the README doesn't cover. Both accurate within scope. **Note:** the README's "Playbooks" table predates the merge and doesn't list `rolling-release-upgrade.yaml`, `rename-node.yaml`, or `showfacts.yaml` — that's staleness, not a contradiction, and out of scope for this PR (filing as separate Issue, see below).
- Other directory READMEs (`services/`, `metallb/`, `helm/collabora/`, WIP notes, `operators/elasticsearch/`) — no contradictions; they're narrower than the CLAUDE.md files and don't overlap on the rules the CLAUDE.md adds.
- **Operator-impact note:** CLAUDE.md files surface workflow rules (decomposition, spec/test-first, PR size, scope discipline) that the operator might otherwise rediscover ad-hoc. Removing those bullets would cost the operator context too, not just Claude — kept them in.

## Follow-up Issues (proposed, not opened by this PR)

1. **README staleness sweep** — `cluster/ansible/README.md` (missing `rolling-release-upgrade.yaml` / `rename-node.yaml` / `showfacts.yaml` / roles) and other per-directory READMEs may have drifted since the recent Ansible overhaul merge. Scope-bounded sweep to bring them current. Independent of this PR.
2. **Hoist `cluster/ansible/` to root `/ansible/`** (optional) — `/shoebox/` lives at root because it's not a Kubernetes resource. By the same logic, `cluster/ansible/` (which provisions the Debian OS, not k8s) could live at `/ansible/`. Doing so would eliminate the 35-line "K8s foundation tax" that `cluster/ansible/CLAUDE.md` currently inherits from `cluster/CLAUDE.md`. Path references in `.github/workflows/{lint,test-ansible}.yaml` and `agentic-review-exceptions.yaml` would need updating.

## Test plan

- [x] `yamllint .` — no new findings (pre-existing warnings unchanged)
- [x] All `@<path>` imports in root `CLAUDE.md` resolve (`README.md`, `dns.md`, `nextcloud.md`, `warehouse.md`, `ansible-scheduler.md`)
- [x] `find . -name AGENTS.md -exec readlink {} +` — every symlink resolves to `CLAUDE.md` in the same directory
- [x] Aggregate-line check ≤200 at every leaf (see table above)
- [x] PR-size self-check (264 LOC; under 400; warning explained above)
- [ ] CI: lint.yaml passes (this PR is Markdown + symlinks; should be a no-op for the YAML/K8s checks)
- [ ] CI: test-ansible.yaml unaffected (no Ansible files touched)
- [ ] CI: test-cluster.yaml unaffected (no manifests touched)

[Claude]


---
_Generated by [Claude Code](https://claude.ai/code/session_014ozi5RAADEGhzUtuXTuNaY)_