### PR TITLE
Don't skip AI review for CLAUDE.md or AGENTS.md changes

### DIFF
--- a/.github/workflows/pr-review.yaml
+++ b/.github/workflows/pr-review.yaml
@@ -43,7 +43,7 @@ jobs:
             --json files --jq '[.files[].path]')
           TOTAL=$(echo "$CHANGED" | jq 'length')
           DOCS=$(echo "$CHANGED" | \
-            jq '[.[] | select(test("\\.(md|txt|rst)$|^docs/|README"))] | length')
+            jq '[.[] | select(test("\\.(md|txt|rst)$|^docs/|README") and (test("(^|/)CLAUDE\\.md$|(^|/)AGENTS\\.md$") | not))] | length')
           if [ "$TOTAL" -gt 0 ] && [ "$TOTAL" -eq "$DOCS" ]; then
             echo "skip=true" >> "$GITHUB_OUTPUT"
             echo "Skipping review: docs-only change ($TOTAL files)"


### PR DESCRIPTION
## Summary

- `CLAUDE.md` and `AGENTS.md` configure AI agent behavior and should be treated as code, not documentation
- The docs-only skip logic in `pr-review.yaml` was classifying them as docs (because they have `.md` extensions), causing AI review to be skipped for PRs that only change those files
- The jq filter now excludes `CLAUDE.md` and `AGENTS.md` from the docs count at any directory depth

## Test plan

- [ ] A PR changing only `CLAUDE.md` should reach the AI review step (skip condition log should not say "docs-only")
- [ ] A PR changing only `README.md` or `docs/something.md` should still be skipped
- [ ] A PR changing both `CLAUDE.md` and a YAML file should not be skipped (unchanged behavior)

https://claude.ai/code/session_015nusyizbijHyxBZJKVP3Jx

---
_Generated by [Claude Code](https://claude.ai/code/session_015nusyizbijHyxBZJKVP3Jx)_