### PR TITLE
feat: PR size gate — soft (200 LOC) and hard (400 LOC) limits

### DIFF
--- a/.github/CLAUDE.md
+++ b/.github/CLAUDE.md
@@ -6,6 +6,7 @@
 - `workflows/test-ansible.yaml` — three jobs: shoebox validators (`shoebox/tests/*.sh`), monkeyble (`cluster/ansible/tests/monkeyble/run-tests.sh`), molecule (`cluster/ansible/molecule/`).
 - `workflows/test-cluster.yaml` — k3d smoke test: spins up a local cluster and applies manifests.
 - `workflows/pr-review.yaml` + `workflows/pr-review-gate.yaml` — Claude AI review + status-check gate.
+- `workflows/pr-size-gate.yaml` — soft (≥200 LOC) and hard (≥400 LOC) PR size limits; `size/override` label bypasses the soft limit.
 - `workflows/autofix.yaml` — fires on `lint.yaml` / `test-cluster.yaml` failure; runs `scripts/autofix.py` (Claude agentic loop: read_file / write_file / run_bash; commits + comments).
 
 ## `autofix.py` invariants — DO NOT BREAK

--- a/.github/workflows/pr-size-gate.yaml
+++ b/.github/workflows/pr-size-gate.yaml
@@ -1,0 +1,56 @@
+name: PR Size Gate
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, labeled, unlabeled]
+
+permissions:
+  pull-requests: read
+  checks: write
+
+jobs:
+  size-check:
+    name: PR size check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check PR size
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const pr = context.payload.pull_request;
+            const loc = pr.additions + pr.deletions;
+            const hasOverride = pr.labels.some(l => l.name === 'size/override');
+
+            let conclusion, title, summary;
+
+            if (loc >= 400) {
+              conclusion = 'failure';
+              title = `PR exceeds hard limit: ${loc} LOC (max 400)`;
+              summary = `This PR changes ${loc} lines (${pr.additions}+ / ${pr.deletions}−). `
+                + `PRs ≥400 LOC must be split before merge. See CLAUDE.md for decomposition guidelines.`;
+            } else if (loc >= 200 && !hasOverride) {
+              conclusion = 'action_required';
+              title = `PR exceeds soft limit: ${loc} LOC (warn ≥200)`;
+              summary = `This PR changes ${loc} lines (${pr.additions}+ / ${pr.deletions}−). `
+                + `PRs ≥200 LOC require manual acknowledgment before merge. `
+                + `A maintainer must add the \`size/override\` label to unblock.`;
+            } else {
+              const note = loc >= 200 ? ' (size/override acknowledged)' : '';
+              conclusion = 'success';
+              title = `PR size: ${loc} LOC — OK${note}`;
+              summary = `${loc} lines changed (${pr.additions}+ / ${pr.deletions}−).`;
+            }
+
+            await github.rest.checks.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              name: 'PR size check',
+              head_sha: pr.head.sha,
+              status: 'completed',
+              conclusion,
+              output: { title, summary }
+            });
+
+            if (conclusion !== 'success') {
+              core.setFailed(title);
+            }

--- a/.github/workflows/pr-size-gate.yaml
+++ b/.github/workflows/pr-size-gate.yaml
@@ -5,6 +5,7 @@ on:
     types: [opened, synchronize, reopened, labeled, unlabeled]
 
 permissions:
+  contents: read
   pull-requests: read
   checks: write
 


### PR DESCRIPTION
## Summary

Closes #17.

- Adds `.github/workflows/pr-size-gate.yaml` enforcing the size limits already documented in CLAUDE.md
- PRs **< 200 LOC**: check passes immediately
- PRs **200–399 LOC**: check fails (`action_required`) until a maintainer adds the `size/override` label — the "manual approval" step
- PRs **≥ 400 LOC**: hard fail, no bypass
- Updates `.github/CLAUDE.md` workflow inventory with one-line description

## Post-merge action required

Add `PR size check` as a required status check in GitHub branch protection for `main` (Settings → Branches → Branch protection rules). Without this the gate runs but doesn't block merge.

## Test plan

- [x] Open a PR with < 200 LOC — check passes green
- [ ] Open a PR with 200–399 LOC — check fails; add `size/override` label — check re-runs and passes
- [ ] Open a PR with ≥ 400 LOC — check fails; label has no effect
- [ ] `yamllint .github/workflows/pr-size-gate.yaml` passes

https://claude.ai/code/session_01LHqpPQCNpkZ8UG7fPqNezs

---
_Generated by [Claude Code](https://claude.ai/code/session_01LHqpPQCNpkZ8UG7fPqNezs)_