### PR TITLE
fix: harden CI supply chain and workflow permissions

### DIFF
--- a/.github/agentic-review-exceptions.yaml
+++ b/.github/agentic-review-exceptions.yaml
@@ -709,6 +709,17 @@ exceptions:
       necessary to propagate molecule's exit code through continue-on-error
       so outcome reflects the actual molecule result.
 
+  - pattern: "autofix run_bash uses denylist / shell=True with LLM-controlled input"
+    files:
+      - .github/scripts/autofix.py
+    reason: >-
+      Intentional design. The bash denylist blocks the most common
+      exfiltration vectors (curl, wget, nc, ncat, netcat, /dev/tcp,
+      ANTHROPIC_*, GH_TOKEN, GITHUB_TOKEN, SECRET). The .github/ write-block
+      prevents CI config tampering. The runner sandbox bounds blast radius.
+      A full allowlist would require reimplementing the repair loop.
+      Accepted homelab tradeoff.
+
 factual_corrections:
   - claim: "Cleanup play won't run if any_errors_fatal hits"
     correction: >-

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -4,6 +4,9 @@ name: Lint
   push:
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
 
   yaml:
@@ -44,7 +47,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: hadolint/hadolint-action@v3.1.0
+      - uses: hadolint/hadolint-action@54c9adbab1582c2ef04b2016b760714a4bfde3cf # v3.1.0
         with:
           recursive: true
           config: .hadolint.yaml
@@ -126,9 +129,15 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Install trivy
+        env:
+          TRIVY_VERSION: 0.71.0
         run: |
-          curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh \
-            | sh -s -- -b /usr/local/bin
+          curl -fsSLo /tmp/trivy.tar.gz \
+            "https://github.com/aquasecurity/trivy/releases/download/v${TRIVY_VERSION}/trivy_${TRIVY_VERSION}_Linux-64bit.tar.gz"
+          curl -fsSLo /tmp/trivy.checksums \
+            "https://github.com/aquasecurity/trivy/releases/download/v${TRIVY_VERSION}/trivy_${TRIVY_VERSION}_checksums.txt"
+          grep "trivy_${TRIVY_VERSION}_Linux-64bit.tar.gz$" /tmp/trivy.checksums | sha256sum -c -
+          tar -xzf /tmp/trivy.tar.gz -C /usr/local/bin trivy
           trivy --version
       - name: Scan Dockerfiles for misconfigurations
         run: |

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -132,12 +132,13 @@ jobs:
         env:
           TRIVY_VERSION: 0.71.0
         run: |
-          curl -fsSLo /tmp/trivy.tar.gz \
-            "https://github.com/aquasecurity/trivy/releases/download/v${TRIVY_VERSION}/trivy_${TRIVY_VERSION}_Linux-64bit.tar.gz"
+          TARBALL="trivy_${TRIVY_VERSION}_Linux-64bit.tar.gz"
+          curl -fsSLo "/tmp/${TARBALL}" \
+            "https://github.com/aquasecurity/trivy/releases/download/v${TRIVY_VERSION}/${TARBALL}"
           curl -fsSLo /tmp/trivy.checksums \
             "https://github.com/aquasecurity/trivy/releases/download/v${TRIVY_VERSION}/trivy_${TRIVY_VERSION}_checksums.txt"
-          grep "trivy_${TRIVY_VERSION}_Linux-64bit.tar.gz$" /tmp/trivy.checksums | sha256sum -c -
-          tar -xzf /tmp/trivy.tar.gz -C /usr/local/bin trivy
+          grep "${TARBALL}$" /tmp/trivy.checksums | (cd /tmp && sha256sum -c -)
+          tar -xzf "/tmp/${TARBALL}" -C /usr/local/bin trivy
           trivy --version
       - name: Scan Dockerfiles for misconfigurations
         run: |

--- a/.github/workflows/test-ansible.yaml
+++ b/.github/workflows/test-ansible.yaml
@@ -50,6 +50,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:
+      contents: read
       pull-requests: write
 
     steps:

--- a/.github/workflows/test-ansible.yaml
+++ b/.github/workflows/test-ansible.yaml
@@ -4,6 +4,9 @@ name: Ansible tests
   push:
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
 
   shoebox-validators:
@@ -76,7 +79,7 @@ jobs:
 
       - name: Post molecule output as PR comment on failure
         if: steps.molecule.outcome == 'failure' && github.event_name == 'pull_request'
-        uses: actions/github-script@v7
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         with:
           script: |
             const fs = require('fs');


### PR DESCRIPTION
## Summary

Security review of the repo and GitHub project. This PR addresses the directly-fixable CI findings; companion issues track the operator-decision items.

- **Replace Trivy `curl | sh main` with pinned versioned download + SHA256 verification.** The previous installer pulled from the mutable `main` branch on every CI run — a compromised install script would execute arbitrary code on the runner (which has `contents: write`). Now pinned to v0.71.0 with checksum gate.
- **Pin `hadolint/hadolint-action` and `actions/github-script` to commit SHAs.** Mutable version tags on third-party actions are a supply chain vector; SHA pins guarantee the exact code that ran during review still runs.
- **Add explicit `permissions: contents: read` to `lint.yaml` and `test-ansible.yaml`.** Both workflows previously inherited the repository default implicitly; explicit declarations follow least-privilege best practice and are visible to code reviewers.
- **Document `autofix.py` bash denylist tradeoff in `agentic-review-exceptions.yaml`.** The `shell=True` + LLM-controlled input design was flagged repeatedly by AI review; the accepted homelab tradeoff is now formally documented so reviewers don't re-raise it.

## Companion issues opened

- #28 — Unifi MongoDB credentials hardcoded in manifest
- #29 — Unifi `insecureSkipVerify: true` disables TLS verification
- #30 — Elasticsearch TLS disabled
- #31 — Redis `ALLOW_EMPTY_PASSWORD: yes` — no authentication
- #32 — MariaDB exposed as LoadBalancer (port 3306)
- #33 — Personal email in `letsencrypt-issuer-prod.yaml`
- #34 — Add security posture statement to README

## Test plan

- [ ] `yamllint .github/workflows/lint.yaml .github/workflows/test-ansible.yaml` passes
- [ ] Lint CI passes (Trivy step uses v0.71.0 tarball with verified checksum)
- [ ] hadolint action SHA `54c9ada` resolves to v3.1.0 tag (verified via `git ls-remote`)
- [ ] github-script SHA `60a0d83` resolves to v7.0.1 tag (verified via `git ls-remote`)
- [ ] `agentic-review-exceptions.yaml` parses cleanly (yamllint passes)

https://claude.ai/code/session_01WtenrARFe7Cna49x26bwEg

---
_Generated by [Claude Code](https://claude.ai/code/session_01WtenrARFe7Cna49x26bwEg)_