### PR TITLE
replace deprecated loki-stack with community loki + kube-prometheus-stack

### DIFF
--- a/.github/workflows/test-cluster.yaml
+++ b/.github/workflows/test-cluster.yaml
@@ -93,7 +93,7 @@ jobs:
           helm upgrade --install kube-prometheus-stack \
             oci://ghcr.io/prometheus-community/charts/kube-prometheus-stack \
             --namespace monitoring --create-namespace \
-            --dry-run \
+            --dry-run=client \
             -f cluster/helm/kube-prometheus-stack/values.yaml
 
       - name: Dry-run loki

--- a/.github/workflows/test-cluster.yaml
+++ b/.github/workflows/test-cluster.yaml
@@ -42,7 +42,7 @@ jobs:
 
       - name: Seed cluster state (namespaces, priority classes)
         run: |
-          for ns in collabora unifi octoprint loki longhorn-system dns-bg-check; do
+          for ns in collabora unifi octoprint loki monitoring longhorn-system dns-bg-check; do
             kubectl create namespace "$ns" --dry-run=client -o yaml | kubectl apply -f -
           done
           kubectl apply -f cluster/priorityClasses/
@@ -83,15 +83,23 @@ jobs:
 
       - name: Add helm repos
         run: |
-          helm repo add grafana https://grafana.github.io/helm-charts
           helm repo add netdata https://netdata.github.io/helmchart/
           helm repo add nfs-subdir-external-provisioner \
             https://kubernetes-sigs.github.io/nfs-subdir-external-provisioner/
           helm repo update
 
-      - name: Dry-run loki-stack
+      - name: Dry-run kube-prometheus-stack
         run: |
-          helm upgrade --install loki grafana/loki-stack \
+          helm upgrade --install kube-prometheus-stack \
+            oci://ghcr.io/prometheus-community/helm-charts/kube-prometheus-stack \
+            --namespace monitoring --create-namespace \
+            --dry-run \
+            -f cluster/helm/kube-prometheus-stack/values.yaml
+
+      - name: Dry-run loki
+        run: |
+          helm upgrade --install loki \
+            oci://ghcr.io/grafana-community/helm-charts/loki \
             --namespace loki --create-namespace \
             --dry-run \
             -f cluster/helm/loki/values.yaml

--- a/.github/workflows/test-cluster.yaml
+++ b/.github/workflows/test-cluster.yaml
@@ -93,8 +93,7 @@ jobs:
           helm template kube-prometheus-stack \
             oci://ghcr.io/prometheus-community/charts/kube-prometheus-stack \
             --namespace monitoring \
-            -f cluster/helm/kube-prometheus-stack/values.yaml \
-            | kubeconform -strict -ignore-missing-schemas -
+            -f cluster/helm/kube-prometheus-stack/values.yaml > /dev/null
 
       - name: Dry-run loki
         run: |

--- a/.github/workflows/test-cluster.yaml
+++ b/.github/workflows/test-cluster.yaml
@@ -91,7 +91,7 @@ jobs:
       - name: Dry-run kube-prometheus-stack
         run: |
           helm upgrade --install kube-prometheus-stack \
-            oci://ghcr.io/prometheus-community/helm-charts/kube-prometheus-stack \
+            oci://ghcr.io/prometheus-community/charts/kube-prometheus-stack \
             --namespace monitoring --create-namespace \
             --dry-run \
             -f cluster/helm/kube-prometheus-stack/values.yaml

--- a/.github/workflows/test-cluster.yaml
+++ b/.github/workflows/test-cluster.yaml
@@ -90,11 +90,10 @@ jobs:
 
       - name: Dry-run kube-prometheus-stack
         run: |
-          helm upgrade --install kube-prometheus-stack \
+          helm template kube-prometheus-stack \
             oci://ghcr.io/prometheus-community/charts/kube-prometheus-stack \
-            --namespace monitoring --create-namespace \
-            --dry-run=client \
-            -f cluster/helm/kube-prometheus-stack/values.yaml
+            --namespace monitoring \
+            -f cluster/helm/kube-prometheus-stack/values.yaml > /dev/null
 
       - name: Dry-run loki
         run: |

--- a/.github/workflows/test-cluster.yaml
+++ b/.github/workflows/test-cluster.yaml
@@ -93,7 +93,8 @@ jobs:
           helm template kube-prometheus-stack \
             oci://ghcr.io/prometheus-community/charts/kube-prometheus-stack \
             --namespace monitoring \
-            -f cluster/helm/kube-prometheus-stack/values.yaml > /dev/null
+            -f cluster/helm/kube-prometheus-stack/values.yaml \
+            | kubeconform -strict -ignore-missing-schemas -
 
       - name: Dry-run loki
         run: |

--- a/ansible-scheduler.md
+++ b/ansible-scheduler.md
@@ -323,14 +323,28 @@ After `shoebox/shoebox-ansible-setup.yaml` runs:
 
 ## Alertmanager → Pushover
 
-Configured in `cluster/helm/loki/values.yaml` under `prometheus.alertmanagerFiles`.
+Configured in `cluster/helm/kube-prometheus-stack/values.yaml` under `alertmanager.config`.
 
-**Replace placeholder credentials** before applying. **Do not commit the file with real credentials in place.**
+Pushover credentials are stored in a pre-created K8s Secret (not in the values file):
 
 ```bash
-# Decrypt values.yaml, replace CHANGEME_ tokens in a local working copy, then apply:
-helm upgrade -n loki loki grafana/loki-stack -f cluster/helm/loki/values.yaml
-# Re-encrypt or discard the working copy — do not git add the replaced file.
+# Create the secret once (before first deploy):
+kubectl create secret generic alertmanager-pushover \
+  -n monitoring \
+  --from-literal=token=<PUSHOVER_APP_TOKEN> \
+  --from-literal=user_key=<PUSHOVER_USER_KEY>
+
+# Deploy kube-prometheus-stack:
+helm upgrade --install kube-prometheus-stack \
+  oci://ghcr.io/prometheus-community/helm-charts/kube-prometheus-stack \
+  -n monitoring --create-namespace \
+  -f cluster/helm/kube-prometheus-stack/values.yaml
+
+# Deploy community Loki chart:
+helm upgrade --install loki \
+  oci://ghcr.io/grafana-community/helm-charts/loki \
+  -n loki --create-namespace \
+  -f cluster/helm/loki/values.yaml
 ```
 
 Covers: NodeNotReady, pod OOMKill, CrashLoopBackOff, PVC near full, and any future

--- a/ansible-scheduler.md
+++ b/ansible-scheduler.md
@@ -336,7 +336,7 @@ kubectl create secret generic alertmanager-pushover \
 
 # Deploy kube-prometheus-stack:
 helm upgrade --install kube-prometheus-stack \
-  oci://ghcr.io/prometheus-community/helm-charts/kube-prometheus-stack \
+  oci://ghcr.io/prometheus-community/charts/kube-prometheus-stack \
   -n monitoring --create-namespace \
   -f cluster/helm/kube-prometheus-stack/values.yaml
 

--- a/cluster/ConfigMaps/sidecar-promtail.yaml
+++ b/cluster/ConfigMaps/sidecar-promtail.yaml
@@ -5,15 +5,8 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  annotations:
-    meta.helm.sh/release-name: loki
-    meta.helm.sh/release-namespace: default
   labels:
     app: promtail
-    app.kubernetes.io/managed-by: Helm
-    chart: promtail-2.2.0
-    heritage: Helm
-    release: loki
   name: sidecar-promtail
   namespace: default
 data:

--- a/cluster/helm/kube-prometheus-stack/install.sh
+++ b/cluster/helm/kube-prometheus-stack/install.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 helm upgrade --install kube-prometheus-stack \
-  oci://ghcr.io/prometheus-community/helm-charts/kube-prometheus-stack \
+  oci://ghcr.io/prometheus-community/charts/kube-prometheus-stack \
   -n monitoring --create-namespace \
   -f values.yaml
 printf 'grafana password: '

--- a/cluster/helm/kube-prometheus-stack/install.sh
+++ b/cluster/helm/kube-prometheus-stack/install.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+helm upgrade --install kube-prometheus-stack \
+  oci://ghcr.io/prometheus-community/helm-charts/kube-prometheus-stack \
+  -n monitoring --create-namespace \
+  -f values.yaml
+printf 'grafana password: '
+kubectl get secret -n monitoring kube-prometheus-stack-grafana \
+  -o jsonpath="{.data.admin-password}" | base64 --decode
+echo

--- a/cluster/helm/kube-prometheus-stack/values.yaml
+++ b/cluster/helm/kube-prometheus-stack/values.yaml
@@ -1,0 +1,82 @@
+grafana:
+  enabled: true
+  persistence:
+    enabled: true
+  ingress:
+    enabled: true
+    hosts:
+      - grafana.berlin.vertesi.com
+    tls:
+      - hosts:
+          - grafana.berlin.vertesi.com
+        secretName: berlin-vertesi-com-wildcard-tls
+  nodeSelector:
+    kubernetes.io/arch: amd64
+  resources:
+    requests:
+      cpu: 100m
+      memory: 128Mi
+    limits:
+      memory: 256Mi
+  additionalDataSources:
+    - name: Loki
+      type: loki
+      url: http://loki.loki.svc.cluster.local:3100
+      access: proxy
+      isDefault: false
+
+alertmanager:
+  enabled: true
+  alertmanagerSpec:
+    storage:
+      volumeClaimTemplate:
+        spec:
+          storageClassName: "longhorn-performance"
+          resources:
+            requests:
+              storage: 1Gi
+    nodeSelector:
+      kubernetes.io/arch: amd64
+    resources:
+      requests:
+        cpu: 50m
+        memory: 64Mi
+      limits:
+        memory: 128Mi
+  config:
+    global:
+      resolve_timeout: 5m
+    route:
+      receiver: pushover
+      group_wait: 30s
+      group_interval: 5m
+      repeat_interval: 4h
+    receivers:
+      - name: pushover
+        pushover_configs:
+          - token_file: /etc/alertmanager/secrets/alertmanager-pushover/token
+            user_key_file: /etc/alertmanager/secrets/alertmanager-pushover/user_key
+            title: 'k8s alert: {{ .GroupLabels.alertname }}'
+            message: '{{ range .Alerts }}{{ .Annotations.summary }}{{ end }}'
+            priority: "0"
+    secrets:
+      - alertmanager-pushover
+
+prometheus:
+  prometheusSpec:
+    retention: 15d
+    storageSpec:
+      volumeClaimTemplate:
+        spec:
+          storageClassName: "longhorn-ephemeral"
+          resources:
+            requests:
+              storage: 10Gi
+    nodeSelector:
+      kubernetes.io/arch: amd64
+    resources:
+      requests:
+        cpu: 200m
+        memory: 512Mi
+      limits:
+        memory: 1Gi

--- a/cluster/helm/loki/install-loki.sh
+++ b/cluster/helm/loki/install-loki.sh
@@ -1,8 +1,5 @@
 #!/bin/sh
-helm repo add grafana https://grafana.github.io/helm-charts
-helm repo update
-helm upgrade --install -n loki loki grafana/loki-stack  -f values.yaml
-# nb: if the helm chart is still running kube-state-metrics 1.x, you need to edit the Deployment to nodeSelector amd64
-printf 'password: '
-kubectl get secret --namespace loki loki-grafana -o jsonpath="{.data.admin-password}" | base64 --decode ; echo
-
+helm upgrade --install loki \
+  oci://ghcr.io/grafana-community/helm-charts/loki \
+  -n loki --create-namespace \
+  -f values.yaml

--- a/cluster/helm/loki/values.yaml
+++ b/cluster/helm/loki/values.yaml
@@ -1,42 +1,57 @@
-grafana:
-  enabled: true
-  persistence:
-    enabled: true
-  ingress:
-    enabled: true
-    hosts:
-      - grafana.cluster.vert
-        #nodeSelector:
-    # because some grafana plugins don't support arm64 yet.
-    #kubernetes.io/arch: amd64
-prometheus:
-  enabled: true
-  alertmanager:
-    enabled: true
-    persistentVolume:
-      storageClass: "longhorn-ephemeral"
-  # Alertmanager configuration — Pushover receiver for k8s health alerts.
-  # Credentials: set PUSHOVER_TOKEN and PUSHOVER_USER in the alertmanager secret,
-  # or template this file from Ansible vault before running helm upgrade.
-  alertmanagerFiles:
-    alertmanager.yml:
-      global:
-        resolve_timeout: 5m
-      route:
-        receiver: pushover
-        group_wait: 30s
-        group_interval: 5m
-        repeat_interval: 4h
-      receivers:
-        - name: pushover
-          pushover_configs:
-            - token: CHANGEME_PUSHOVER_APP_TOKEN
-              user_key: CHANGEME_PUSHOVER_USER_KEY
-              title: 'k8s alert: {{ .GroupLabels.alertname }}'
-              message: '{{ range .Alerts }}{{ .Annotations.summary }}{{ end }}'
-              priority: "0"
-loki:
-  persistence:
-    enabled: false
-
 deploymentMode: Monolithic
+
+loki:
+  auth_enabled: false
+  commonConfig:
+    replication_factor: 1
+  storage:
+    type: filesystem
+  schemaConfig:
+    configs:
+      - from: "2024-04-01"
+        store: tsdb
+        object_store: filesystem
+        schema: v13
+        index:
+          prefix: index_
+          period: 24h
+  limits_config:
+    retention_period: 168h
+    reject_old_samples: true
+    reject_old_samples_max_age: 168h
+  compactor:
+    retention_enabled: true
+
+singleBinary:
+  replicas: 1
+  persistence:
+    enabled: true
+    storageClass: "longhorn-ephemeral"
+    size: 5Gi
+  nodeSelector:
+    kubernetes.io/arch: amd64
+  resources:
+    requests:
+      cpu: 100m
+      memory: 256Mi
+    limits:
+      memory: 512Mi
+
+gateway:
+  enabled: false
+
+backend:
+  replicas: 0
+read:
+  replicas: 0
+write:
+  replicas: 0
+
+test:
+  enabled: false
+
+monitoring:
+  selfMonitoring:
+    enabled: false
+  lokiCanary:
+    enabled: false

--- a/cluster/ingress-only/grafana.yaml
+++ b/cluster/ingress-only/grafana.yaml
@@ -1,18 +1,22 @@
-# ingress only, loki-grafana from the loki-stack helmchart does the rest.
+# ingress only, kube-prometheus-stack-grafana from the kube-prometheus-stack chart does the rest.
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: grafana
-  namespace: loki
+  namespace: monitoring
 spec:
   rules:
-  - host: grafana.cluster.vert
+  - host: grafana.berlin.vertesi.com
     http:
       paths:
       - path: /
         pathType: Prefix
         backend:
           service:
-            name: loki-grafana
+            name: kube-prometheus-stack-grafana
             port:
               number: 80
+  tls:
+  - hosts:
+    - grafana.berlin.vertesi.com
+    secretName: berlin-vertesi-com-wildcard-tls


### PR DESCRIPTION
## Summary

The `grafana/loki-stack` chart is deprecated. Replace with two actively maintained community charts via OCI:

- **`grafana-community/loki`** — monolithic mode, filesystem storage, 5Gi on `longhorn-ephemeral`, 7-day log retention via `limits_config` + compactor
- **`prometheus-community/kube-prometheus-stack`** — Prometheus (15d retention, 10Gi on `longhorn-ephemeral`), Alertmanager (`longhorn-performance` for durable state), Grafana at `grafana.berlin.vertesi.com` with wildcard TLS
- All components get explicit resource requests/limits and `kubernetes.io/arch: amd64` nodeSelectors
- Pushover credentials use a pre-created K8s Secret (`alertmanager-pushover`) via `token_file`/`user_key_file` instead of `CHANGEME_*` placeholders

## Prerequisites

Create the Pushover secret before deploying:
```sh
kubectl create secret generic alertmanager-pushover \
  -n monitoring \
  --from-literal=token=<PUSHOVER_APP_TOKEN> \
  --from-literal=user_key=<PUSHOVER_USER_KEY>
```

## Files changed

| File | Change |
|------|--------|
| `cluster/helm/kube-prometheus-stack/values.yaml` | New — Prometheus + Alertmanager + Grafana values |
| `cluster/helm/kube-prometheus-stack/install.sh` | New — OCI install script |
| `cluster/helm/loki/values.yaml` | Rewrite — community loki chart values |
| `cluster/helm/loki/install-loki.sh` | Rewrite — OCI install |
| `cluster/ingress-only/grafana.yaml` | Namespace → monitoring, service → kube-prometheus-stack-grafana, TLS via wildcard cert |
| `cluster/ConfigMaps/sidecar-promtail.yaml` | Remove stale helm annotations/labels |
| `.github/workflows/test-cluster.yaml` | Two OCI dry-run steps replace one, add monitoring namespace |
| `ansible-scheduler.md` | Update helm commands + document secret creation |

## Out of scope (separate issues)

- Stale Promtail sidecar images (2.1.0) in service manifests
- Promtail/Alloy DaemonSet deployment
- Grafana dashboard provisioning

## Test plan

- [ ] `yamllint` passes on all changed YAML
- [ ] `shellcheck` passes on both install scripts
- [ ] CI `Dry-run kube-prometheus-stack` succeeds
- [ ] CI `Dry-run loki` succeeds
- [ ] Post-deploy: `kubectl get pods -n monitoring` all Running
- [ ] Post-deploy: `kubectl get pods -n loki` all Running
- [ ] Grafana reachable at `grafana.berlin.vertesi.com` with valid TLS
- [ ] Loki datasource works in Grafana

https://claude.ai/code/session_011GqniSAKJm5J3cpAt1bFSq