### PR TITLE
fix: add compactor.delete_request_store for loki retention

### DIFF
--- a/cluster/helm/loki/values.yaml
+++ b/cluster/helm/loki/values.yaml
@@ -21,6 +21,7 @@ loki:
     reject_old_samples_max_age: 168h
   compactor:
     retention_enabled: true
+    delete_request_store: filesystem
 
 singleBinary:
   replicas: 1


### PR DESCRIPTION
## Summary

- Loki pod `loki-0` fails to start with: `compactor.delete-request-store should be configured when retention is enabled`
- Adds `delete_request_store: filesystem` to `loki.compactor` in the Helm values, matching the existing `storage.type: filesystem`

## Test plan

- [ ] Apply the updated Helm values: `helm upgrade loki` with the new values
- [ ] Verify `loki-0` pod starts successfully (`kubectl wait --for=condition=Ready pod/loki-0`)
- [ ] Confirm retention deletes work by checking compactor logs for delete-request processing

https://claude.ai/code/session_01UJDTVdcz6AWAvhRWRuEe2H

---
_Generated by [Claude Code](https://claude.ai/code/session_01UJDTVdcz6AWAvhRWRuEe2H)_