### PR TITLE
fix: skip TLS verify for loki-sc-rules sidecar

### DIFF
--- a/cluster/helm/loki/values.yaml
+++ b/cluster/helm/loki/values.yaml
@@ -38,6 +38,13 @@ singleBinary:
     limits:
       memory: 512Mi
 
+sidecar:
+  rules:
+    # k3s CA cert lacks Authority Key Identifier extension;
+    # Python 3.13+ in the sidecar image rejects it.
+    # Tracked: regenerate k3s CA with AKI/SKI extensions.
+    skipTlsVerify: true
+
 gateway:
   enabled: false
 

--- a/cluster/helm/loki/values.yaml
+++ b/cluster/helm/loki/values.yaml
@@ -39,11 +39,10 @@ singleBinary:
       memory: 512Mi
 
 sidecar:
-  rules:
-    # k3s CA cert lacks Authority Key Identifier extension;
-    # Python 3.13+ in the sidecar image rejects it.
-    # Tracked: regenerate k3s CA with AKI/SKI extensions.
-    skipTlsVerify: true
+  # k3s CA cert lacks Authority Key Identifier extension;
+  # Python 3.13+ in the sidecar image rejects it.
+  # Tracked: regenerate k3s CA with AKI/SKI extensions.
+  skipTlsVerify: true
 
 gateway:
   enabled: false


### PR DESCRIPTION
## Summary

- `loki-sc-rules` sidecar fails to connect to the K8s API due to the k3s CA cert missing the Authority Key Identifier extension, which Python 3.13+ now enforces
- Adds `sidecar.rules.skipTlsVerify: true` to the Loki Helm values, matching the existing workaround in `kube-prometheus-stack` for the Grafana sidecar

## Test plan

- [ ] `helm upgrade --install loki` with updated values
- [ ] Verify `loki-sc-rules` container starts without SSL errors
- [ ] Verify Loki rules loading works if any `loki_rule`-labelled secrets exist

https://claude.ai/code/session_01JJpfDjhEmCRXxVZo8CLUjm

---
_Generated by [Claude Code](https://claude.ai/code/session_01JJpfDjhEmCRXxVZo8CLUjm)_