### PR TITLE
feat: deploy Grafana Alloy DaemonSet for cluster-wide log collection

### DIFF
--- a/.github/workflows/test-cluster.yaml
+++ b/.github/workflows/test-cluster.yaml
@@ -83,6 +83,7 @@ jobs:
 
       - name: Add helm repos
         run: |
+          helm repo add grafana https://grafana.github.io/helm-charts
           helm repo add netdata https://netdata.github.io/helmchart/
           helm repo add nfs-subdir-external-provisioner \
             https://kubernetes-sigs.github.io/nfs-subdir-external-provisioner/
@@ -108,6 +109,13 @@ jobs:
           helm upgrade --install netdata netdata/netdata \
             --dry-run \
             -f cluster/helm/netdata/override.yaml
+
+      - name: Dry-run alloy
+        run: |
+          helm upgrade --install alloy grafana/alloy \
+            --namespace monitoring --create-namespace \
+            --dry-run \
+            -f cluster/helm/alloy/values.yaml
 
       - name: Dry-run nfs-subdir-external-provisioner
         run: |

--- a/cluster/helm/alloy/install-alloy.sh
+++ b/cluster/helm/alloy/install-alloy.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+helm repo add grafana https://grafana.github.io/helm-charts
+helm repo update grafana
+helm upgrade --install alloy grafana/alloy \
+  -n monitoring --create-namespace \
+  -f values.yaml

--- a/cluster/helm/alloy/values.yaml
+++ b/cluster/helm/alloy/values.yaml
@@ -1,0 +1,60 @@
+alloy:
+  configMap:
+    content: |
+      discovery.kubernetes "pods" {
+        role = "pod"
+      }
+
+      discovery.relabel "pods" {
+        targets = discovery.kubernetes.pods.targets
+
+        rule {
+          source_labels = ["__meta_kubernetes_namespace"]
+          target_label  = "namespace"
+        }
+        rule {
+          source_labels = ["__meta_kubernetes_pod_name"]
+          target_label  = "pod"
+        }
+        rule {
+          source_labels = ["__meta_kubernetes_pod_container_name"]
+          target_label  = "container"
+        }
+        rule {
+          source_labels = ["__meta_kubernetes_pod_node_name"]
+          target_label  = "node_name"
+        }
+        rule {
+          source_labels = ["__meta_kubernetes_namespace", "__meta_kubernetes_pod_container_name"]
+          separator     = "/"
+          target_label  = "job"
+        }
+      }
+
+      loki.source.kubernetes "pods" {
+        targets    = discovery.relabel.pods.output
+        forward_to = [loki.write.loki.receiver]
+      }
+
+      loki.write "loki" {
+        endpoint {
+          url = "http://loki.loki.svc.cluster.local:3100/loki/api/v1/push"
+        }
+      }
+
+  resources:
+    requests:
+      cpu: 50m
+      memory: 128Mi
+    limits:
+      memory: 256Mi
+
+controller:
+  type: daemonset
+  tolerations:
+    - key: node-role.kubernetes.io/control-plane
+      operator: Exists
+      effect: NoSchedule
+    - key: node-role.kubernetes.io/master
+      operator: Exists
+      effect: NoSchedule


### PR DESCRIPTION
## Summary

- Deploy Grafana Alloy as a DaemonSet in the `monitoring` namespace to collect pod stdout/stderr cluster-wide and ship to Loki with standard Kubernetes labels (`namespace`, `pod`, `container`, `node_name`, `job`)
- Uses `loki.source.kubernetes` (Kubernetes API-based collection) — no host filesystem mounts, no privileged access, no CRI parsing needed
- Tolerates control-plane/master node taints for full node coverage
- Adds Alloy Helm dry-run to CI (`test-cluster.yaml`)

**Problem:** Grafana dashboard #16976 queries Loki with `{namespace=, container=}` but no cluster-wide collector exists. Only promtail sidecars on a few pods ship logs, all with `container=promtail-sidecar`. Every dashboard query returns zero results.

**No regression:** Existing promtail sidecars (Plex, Nextcloud, Duplicacy) read app log files via emptyDir volumes — Alloy reads container stdout/stderr via K8s API. Independent collection paths, no conflict.

## Test plan

- [ ] CI: `yamllint` passes on `cluster/helm/alloy/values.yaml`
- [ ] CI: `shellcheck` passes on `cluster/helm/alloy/install-alloy.sh`
- [ ] CI: `helm upgrade --install alloy grafana/alloy --dry-run` succeeds in `test-cluster.yaml`
- [ ] Post-deploy: `curl http://loki:3100/loki/api/v1/label/namespace/values` returns all active namespaces
- [ ] Post-deploy: Grafana dashboard #16976 populates when selecting any valid namespace/container pair
- [ ] Post-deploy: Existing promtail sidecar streams for Plex and Nextcloud continue to ingest

https://claude.ai/code/session_01BReCd7g4ojuU8WNQV2h4WP

---
_Generated by [Claude Code](https://claude.ai/code/session_01BReCd7g4ojuU8WNQV2h4WP)_